### PR TITLE
taking offense for religious or political comment is not harrassement

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Our open source community strives to:
 
 Harassment includes, but is not limited to:
 
-- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, age, regional discrimination, political or religious affiliation
+- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, age, regional discrimination
 - Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment
 - Deliberate misgendering. This includes deadnaming or persistently using a pronoun that does not correctly reflect a person's gender identity. You must address people by the name they give you when not addressing them by their username or handle
 - Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop


### PR DESCRIPTION
As stated here : https://github.com/todogroup/opencodeofconduct/issues/75
the meme version : https://pbs.twimg.com/media/B7Wz261CIAAQLs4.jpg:large

While all other traits are intrinsically constitutive of the person, religion is only an opinion that anyone is free to change at anytime.

I do not welcome or advocate discrimination and harassment of people for their beliefs.
I really believe in respect of the person (and that it must be enforced), but do not think opinions are worthy of such respect. That would in fact be a dangerous idea for liberties.

However as stated in the policy now, it becomes harassment to merely offend religious people. That is extremely wrong. Religious people can chose to be offended by anything. According a "right not to be offended", is going counter to all advance by modern societies. Is is very wrong and very dangerous to put religions (just an other opinion) on the same level as intrinsic properties of what a person is : sex, genre, race, etc...

Historically (and still very much now!) religions have been the primary sources of obscurantism and persecutions. Societies fought back and began separating states and religions, according a right to blasphemy in many cases. The right to blasphemy has been primordial in freeing people from the control of churches.

Nowadays, we see a weakening of the Age of Enlightenment's philosophical advances : https://en.wikipedia.org/wiki/Age_of_Enlightenment
Religious groups everywhere try to weaken once again civil liberties by asking for this right to be offended and to forbid blasphemy.

Letting them having their way redefining what is socially acceptable would be a moral and philosophical regression. Accepting this would not be fighting against discrimination but calling for it.